### PR TITLE
Improve local deployment

### DIFF
--- a/device-animation-test-rule/build.gradle
+++ b/device-animation-test-rule/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
+
 group='com.github.VictorAlbertos'
+version='0.0.1'
 
 android {
   compileSdkVersion 24

--- a/device-animation-test-rule/build.gradle
+++ b/device-animation-test-rule/build.gradle
@@ -13,6 +13,7 @@ android {
     targetSdkVersion 24
     versionCode 1
     versionName "1.0"
+    archivesBaseName = "DeviceAnimationTestRule"
   }
   buildTypes {
     release {


### PR DESCRIPTION
Specify library version so it can be used by the "install" task.

+ The android-maven plugin picks up the version to generate the artifacts
  with a version number and publish them in the following folder:
  ~/.m2/repository/com/github/VictorAlbertos/device-animation-test-rule/0.0.1

---

Use same artifact names for local deployment as being used via JitPack.

+ Changes ~/.m2/repository/com/github/VictorAlbertos/device-animation-test-rule/
  to ~/.m2/repository/com/github/VictorAlbertos/DeviceAnimationTestRule/